### PR TITLE
feat: 부산시 대기질 정보 조회 기능 추가

### DIFF
--- a/src/main/java/com/example/air/application/AirQualityService.java
+++ b/src/main/java/com/example/air/application/AirQualityService.java
@@ -1,6 +1,5 @@
 package com.example.air.application;
 
-import com.example.air.infrastructure.api.seoul.SeoulAirQualityApiCaller;
 import com.example.air.interfaces.api.dto.AirQualityDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -10,17 +9,15 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class AirQualityService {
-    private final SeoulAirQualityApiCaller seoulAirQualityApiCaller;
+    private final KoreaAirQualityServiceFactory koreaAirQualityServiceFactory;
 
     public AirQualityDto.GetAirQualityInfo getAirQualityInfo(Sido sido, String gu) {
-        if (sido == Sido.seoul) {
-            var airQualityInfo = seoulAirQualityApiCaller.getAirQuality();
-            if (gu != null) {
-                return airQualityInfo.searchByGu(gu);
-            }
-            return airQualityInfo;
+        KoreaAirQualityService service = koreaAirQualityServiceFactory.getService(sido);
+        
+        var airQualityInfo = service.getAirQualityInfo();
+        if (gu != null) {
+            return airQualityInfo.searchByGu(gu);
         }
-
-        throw new RuntimeException(sido + " 대기질 정보는 아직 준비중입니다.");
+        return airQualityInfo;
     }
 }

--- a/src/main/java/com/example/air/application/KoreaAirQualityService.java
+++ b/src/main/java/com/example/air/application/KoreaAirQualityService.java
@@ -1,0 +1,9 @@
+package com.example.air.application;
+
+import com.example.air.interfaces.api.dto.AirQualityDto;
+
+public interface KoreaAirQualityService {
+    Sido getSido();
+
+    AirQualityDto.GetAirQualityInfo getAirQualityInfo();
+}

--- a/src/main/java/com/example/air/application/KoreaAirQualityServiceFactory.java
+++ b/src/main/java/com/example/air/application/KoreaAirQualityServiceFactory.java
@@ -1,0 +1,28 @@
+package com.example.air.application;
+
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+@Component
+public class KoreaAirQualityServiceFactory {
+    private final Map<Sido, KoreaAirQualityService> serviceMap = new HashMap<>();
+
+    /**
+     * 생성자를 통해 KoreaAirQualityService 를 상속받은 서비스를 key : value 형태로 저장함
+     * { seoul : SeoulAirQualityApiCaller, busan : BusanAirQualityApiCaller }
+     */
+    public KoreaAirQualityServiceFactory(List<KoreaAirQualityService> services) {
+        for (var service : services) {
+            serviceMap.put(service.getSido(), service);
+        }
+    }
+
+    public KoreaAirQualityService getService(Sido sido) {
+        return Optional.of(serviceMap.get(sido))
+                .orElseThrow(() -> new RuntimeException("대기질 정보를 조회할 수 없는 시/도 입니다."));
+    }
+}

--- a/src/main/java/com/example/air/infrastructure/api/busan/BusanAirQualityApiDto.java
+++ b/src/main/java/com/example/air/infrastructure/api/busan/BusanAirQualityApiDto.java
@@ -52,20 +52,11 @@ public class BusanAirQualityApiDto {
         private String areaIndex;
         @JsonProperty("controlnumber")
         private String measurementTime;
-        private String repItem;
-        private String repVal;
-        private String repCai;
-        private String so2;
-        private String so2Cai;
-        private String no2;
-        private String no2Cai;
-        private String o3;
-        private String o3Cai;
-        private String co;
-        private String coCai;
-        private String pm25;
-        private String pm25Cai;
-        private String pm10;
-        private String pm10Cai;
+        private Double so2;
+        private Double no2;
+        private Double o3;
+        private Double co;
+        private Integer pm25;
+        private Integer pm10;
     }
 }

--- a/src/main/java/com/example/air/infrastructure/api/seoul/SeoulAirQualityApiCaller.java
+++ b/src/main/java/com/example/air/infrastructure/api/seoul/SeoulAirQualityApiCaller.java
@@ -1,5 +1,6 @@
 package com.example.air.infrastructure.api.seoul;
 
+import com.example.air.application.KoreaAirQualityService;
 import com.example.air.application.Sido;
 import com.example.air.application.util.AirQualityGradeUtil;
 import com.example.air.interfaces.api.dto.AirQualityDto;
@@ -19,7 +20,7 @@ import java.util.stream.Collectors;
 
 @Slf4j
 @Component
-public class SeoulAirQualityApiCaller {
+public class SeoulAirQualityApiCaller implements KoreaAirQualityService {
     private final SeoulAirQualityApi seoulAirQualityApi;
 
     public SeoulAirQualityApiCaller(@Value("${api.seoul.base-url}") String baseUrl) {
@@ -34,7 +35,13 @@ public class SeoulAirQualityApiCaller {
         this.seoulAirQualityApi = retrofit.create(SeoulAirQualityApi.class);
     }
 
-    public AirQualityDto.GetAirQualityInfo getAirQuality() {
+    @Override
+    public Sido getSido() {
+        return Sido.seoul;
+    }
+
+    @Override
+    public AirQualityDto.GetAirQualityInfo getAirQualityInfo() {
         try {
             String date = getDateAnHourAgo();
             var call = seoulAirQualityApi.getAirQuality(date);

--- a/src/main/java/com/example/air/interfaces/api/dto/AirQualityDto.java
+++ b/src/main/java/com/example/air/interfaces/api/dto/AirQualityDto.java
@@ -23,12 +23,12 @@ public class AirQualityDto {
                 return this;
             }
             var searchedGuInfo = searchGuAirQualityInfo(gu);
-            guList = Collections.singletonList(searchedGuInfo);
+            this.guList = Collections.singletonList(searchedGuInfo);
             return this;
         }
 
         private GuAirQualityInfo searchGuAirQualityInfo(String gu) {
-            return guList.stream()
+            return this.guList.stream()
                     .filter(guAirQualityInfo -> guAirQualityInfo.getGu().equals(gu))
                     .findFirst()
                     .orElseThrow(() -> new IllegalArgumentException(gu + "에 해당하는 자치구가 존재하지 않습니다."));
@@ -39,16 +39,16 @@ public class AirQualityDto {
     public static class GuAirQualityInfo {
         private final String gu;
         private final Integer pm10;
-        private final Integer pm25;
-        private final Double o3;
-        private final Double no2;
-        private final Double co;
-        private final Double so2;
         private final AirQualityGrade pm10Grade;
+        private final Integer pm25;
         private final AirQualityGrade pm25Grade;
+        private final Double o3;
         private final AirQualityGrade o3Grade;
+        private final Double no2;
         private final AirQualityGrade no2Grade;
+        private final Double co;
         private final AirQualityGrade coGrade;
+        private final Double so2;
         private final AirQualityGrade so2Grade;
 
         public GuAirQualityInfo(String gu, Integer pm10, Integer pm25, Double o3, Double no2, Double co, Double so2) {

--- a/src/test/java/com/example/air/infrastructure/api/seoul/SeoulAirQualityApiCallerTest.java
+++ b/src/test/java/com/example/air/infrastructure/api/seoul/SeoulAirQualityApiCallerTest.java
@@ -15,7 +15,7 @@ class SeoulAirQualityApiCallerTest {
     @Test
     public void 서울_대기질_조회_API_호출() {
         // when
-        var response = seoulAirQualityApiCaller.getAirQuality();
+        var response = seoulAirQualityApiCaller.getAirQualityInfo();
 
         // then
         assertNotNull(response);


### PR DESCRIPTION
[코멘토 3주차 과제]
기존 API 에서 부산시 대기질 정보도 조회 가능하도록 추가한다.

[안내]
코드와 함께 아래 코멘트들을 참고 부탁드립니다.
해당 내용은 5주차 온라인 세션에서 다시 자세히 설명드립니다.